### PR TITLE
fix: enforce TTL expiration across all read paths

### DIFF
--- a/src/agent_memory_store/storage.py
+++ b/src/agent_memory_store/storage.py
@@ -112,6 +112,10 @@ class ScoredMemory:
     relevance_score: float = 0.0
 
 
+# Use strftime with T separator to match Python's isoformat() for correct comparison
+_TTL_FILTER = "AND (expires_at IS NULL OR expires_at > strftime('%Y-%m-%dT%H:%M:%f', 'now'))"
+
+
 class MemoryStorage:
     """SQLite-backed memory storage with FTS5 and optional semantic search."""
 
@@ -258,6 +262,24 @@ class MemoryStorage:
             embedding = embeddings.get_embedding(text_to_embed)
 
         with self._get_connection() as conn:
+            # Opportunistic cleanup: delete expired memories
+            expired_ids = [
+                row[0]
+                for row in conn.execute(
+                    "SELECT id FROM memories"
+                    " WHERE expires_at IS NOT NULL"
+                    " AND expires_at <= strftime('%Y-%m-%dT%H:%M:%f', 'now')"
+                ).fetchall()
+            ]
+            if expired_ids:
+                placeholders = ",".join("?" * len(expired_ids))
+                conn.execute(f"DELETE FROM memories WHERE id IN ({placeholders})", expired_ids)
+                if self._vec_available:
+                    conn.execute(
+                        f"DELETE FROM memories_vec WHERE memory_id IN ({placeholders})",
+                        expired_ids,
+                    )
+
             # Check if key already exists to get the existing id
             cursor = conn.execute("SELECT id FROM memories WHERE key = ?", (key,))
             existing = cursor.fetchone()
@@ -325,19 +347,19 @@ class MemoryStorage:
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.execute(
-                "SELECT * FROM memories WHERE key = ?",
+                f"SELECT * FROM memories WHERE key = ? {_TTL_FILTER}",
                 (key,),
             )
             row = cursor.fetchone()
             if not row:
                 return None
 
-            # Update access stats
+            # Update access stats (only for non-expired memories)
             conn.execute(
-                """
+                f"""
                 UPDATE memories
                 SET access_count = access_count + 1, last_accessed_at = ?
-                WHERE key = ?
+                WHERE key = ? {_TTL_FILTER}
                 """,
                 (datetime.now(UTC).isoformat(), key),
             )
@@ -370,10 +392,10 @@ class MemoryStorage:
             escaped_query = self._escape_fts5_query(query)
 
             # Build query with optional filters
-            sql = """
+            sql = f"""
                 SELECT m.* FROM memories m
                 JOIN memories_fts fts ON m.rowid = fts.rowid
-                WHERE memories_fts MATCH ?
+                WHERE memories_fts MATCH ? {_TTL_FILTER}
             """
             params: list = [escaped_query]
 
@@ -461,6 +483,10 @@ class MemoryStorage:
             for row in rows:
                 memory = self._row_to_memory(row)
 
+                # Filter expired memories
+                if memory.expires_at is not None and memory.expires_at <= datetime.now(UTC):
+                    continue
+
                 # Apply namespace filter
                 if namespace and memory.namespace != namespace:
                     continue
@@ -512,7 +538,7 @@ class MemoryStorage:
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
 
-            sql = "SELECT * FROM memories WHERE 1=1"
+            sql = f"SELECT * FROM memories WHERE 1=1 {_TTL_FILTER}"
             params: list = []
 
             if namespace:
@@ -574,7 +600,7 @@ class MemoryStorage:
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
 
-            sql = "SELECT * FROM memories WHERE 1=1"
+            sql = f"SELECT * FROM memories WHERE 1=1 {_TTL_FILTER}"
             params: list = []
 
             # Namespace filter
@@ -666,42 +692,48 @@ class MemoryStorage:
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
 
+            _live = f"WHERE 1=1 {_TTL_FILTER}"
+
             # Total count
-            total = conn.execute("SELECT COUNT(*) as cnt FROM memories").fetchone()["cnt"]
+            total = conn.execute(f"SELECT COUNT(*) as cnt FROM memories {_live}").fetchone()["cnt"]
 
             # Namespace distribution
             namespaces = {}
             for row in conn.execute(
-                "SELECT namespace, COUNT(*) as cnt FROM memories GROUP BY namespace"
+                f"SELECT namespace, COUNT(*) as cnt FROM memories {_live} GROUP BY namespace"
             ):
                 namespaces[row["namespace"]] = row["cnt"]
 
             # Tag distribution (requires parsing JSON)
             tags: dict[str, int] = {}
-            for row in conn.execute("SELECT tags FROM memories"):
+            for row in conn.execute(f"SELECT tags FROM memories {_live}"):
                 for tag in json.loads(row["tags"]):
                     tags[tag] = tags.get(tag, 0) + 1
 
             # Importance distribution
             importance_dist = {}
             for row in conn.execute(
-                "SELECT importance, COUNT(*) as cnt FROM memories GROUP BY importance"
+                f"SELECT importance, COUNT(*) as cnt FROM memories {_live} GROUP BY importance"
             ):
                 importance_dist[row["importance"]] = row["cnt"]
 
             # Date range
             date_row = conn.execute(
-                "SELECT MIN(created_at) as oldest, MAX(created_at) as newest FROM memories"
+                f"SELECT MIN(created_at) as oldest, MAX(created_at) as newest FROM memories {_live}"
             ).fetchone()
             oldest = datetime.fromisoformat(date_row["oldest"]) if date_row["oldest"] else None
             newest = datetime.fromisoformat(date_row["newest"]) if date_row["newest"] else None
 
             # Average importance
-            avg_row = conn.execute("SELECT AVG(importance) as avg_imp FROM memories").fetchone()
+            avg_row = conn.execute(
+                f"SELECT AVG(importance) as avg_imp FROM memories {_live}"
+            ).fetchone()
             avg_importance = avg_row["avg_imp"] or 0.0
 
             # Total access count
-            access_row = conn.execute("SELECT SUM(access_count) as total FROM memories").fetchone()
+            access_row = conn.execute(
+                f"SELECT SUM(access_count) as total FROM memories {_live}"
+            ).fetchone()
             total_access = access_row["total"] or 0
 
             return MemoryStats(
@@ -806,14 +838,14 @@ class MemoryStorage:
         Returns:
             Dict with aggregation results.
         """
-        # First apply filters to get the subset
+        # First apply filters to get the subset (query() already filters expired)
         if filters:
             memories = self.query(filters)
         else:
-            # Get all memories
+            # Get all live memories
             with sqlite3.connect(self.db_path) as conn:
                 conn.row_factory = sqlite3.Row
-                cursor = conn.execute("SELECT * FROM memories")
+                cursor = conn.execute(f"SELECT * FROM memories WHERE 1=1 {_TTL_FILTER}")
                 memories = [self._row_to_memory(row) for row in cursor.fetchall()]
 
         result: dict = {"group_by": group_by, "groups": {}, "total": len(memories)}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Pytest fixtures for agent-memory-store tests."""
 
+import sqlite3
 import tempfile
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -21,3 +23,15 @@ def temp_db():
 def storage(temp_db):
     """Create a MemoryStorage instance with a temp database."""
     return MemoryStorage(temp_db)
+
+
+@pytest.fixture
+def expire_memory(temp_db):
+    """Manually expire a memory by setting expires_at to the past."""
+
+    def _expire(key: str):
+        with sqlite3.connect(temp_db) as conn:
+            past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+            conn.execute("UPDATE memories SET expires_at = ? WHERE key = ?", (past, key))
+
+    return _expire

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,10 +1,10 @@
-"""Unit tests for storage.py - CRUD, FTS5, and TTL functionality."""
+"""Unit tests for storage.py - CRUD, FTS5, TTL functionality, and TTL enforcement."""
 
 import json
 import sqlite3
 from datetime import UTC, datetime, timedelta
 
-from agent_memory_store.storage import Memory, MemoryStorage
+from agent_memory_store.storage import Memory, MemoryStorage, QueryFilters
 
 
 class TestMemoryDataclass:
@@ -464,3 +464,130 @@ class TestEdgeCases:
         recalled = storage.recall_by_key("json-data")
         parsed = json.loads(recalled.value)
         assert parsed == data
+
+
+class TestTTLEnforcement:
+    """Tests that expired memories are excluded from all read paths."""
+
+    def test_expired_excluded_from_recall_by_key(self, storage, expire_memory):
+        """Expired memory should not be returned by recall_by_key."""
+        storage.store(key="temp", value="data", ttl_days=7)
+        expire_memory("temp")
+
+        assert storage.recall_by_key("temp") is None
+
+    def test_expired_excluded_from_search(self, storage, expire_memory):
+        """Expired memory should not appear in FTS search results."""
+        storage.store(key="searchable", value="unique findme content", ttl_days=7)
+        expire_memory("searchable")
+
+        results = storage.search("findme")
+        assert len(results) == 0
+
+    def test_expired_excluded_from_list(self, storage, expire_memory):
+        """Expired memory should not appear in list_memories."""
+        storage.store(key="live", value="visible")
+        storage.store(key="dead", value="hidden", ttl_days=7)
+        expire_memory("dead")
+
+        memories = storage.list_memories()
+        keys = {m.key for m in memories}
+        assert "live" in keys
+        assert "dead" not in keys
+
+    def test_expired_excluded_from_query(self, storage, expire_memory):
+        """Expired memory should not appear in query results."""
+        storage.store(key="q-live", value="visible", namespace="test")
+        storage.store(key="q-dead", value="hidden", namespace="test", ttl_days=7)
+        expire_memory("q-dead")
+
+        results = storage.query(QueryFilters(namespace="test"))
+        keys = {m.key for m in results}
+        assert "q-live" in keys
+        assert "q-dead" not in keys
+
+    def test_expired_excluded_from_explore(self, storage, expire_memory):
+        """Expired memories should not be counted in explore() statistics."""
+        storage.store(key="e1", value="one")
+        storage.store(key="e2", value="two")
+        storage.store(key="e3", value="three", ttl_days=7)
+        expire_memory("e3")
+
+        stats = storage.explore()
+        assert stats.total_count == 2
+
+    def test_expired_excluded_from_aggregate(self, storage, expire_memory):
+        """Expired memories should not appear in aggregate results."""
+        storage.store(key="a1", value="one", namespace="ns")
+        storage.store(key="a2", value="two", namespace="ns", ttl_days=7)
+        expire_memory("a2")
+
+        result = storage.aggregate(group_by="namespace")
+        assert result["total"] == 1
+        assert result["groups"]["ns"] == 1
+
+    def test_non_expired_memory_still_returned(self, storage):
+        """Memory with TTL that hasn't expired should still be visible."""
+        memory = storage.store(key="fresh", value="still alive", ttl_days=30)
+        assert memory.expires_at is not None
+
+        recalled = storage.recall_by_key("fresh")
+        assert recalled is not None
+        assert recalled.key == "fresh"
+
+        results = storage.search("alive")
+        assert len(results) == 1
+
+        memories = storage.list_memories()
+        assert len(memories) == 1
+
+    def test_no_ttl_memory_unaffected(self, storage):
+        """Memory without TTL should always be returned."""
+        storage.store(key="permanent", value="forever")
+        recalled = storage.recall_by_key("permanent")
+        assert recalled is not None
+        assert recalled.expires_at is None
+
+    def test_expired_memory_not_access_counted(self, storage, expire_memory, temp_db):
+        """Recalling an expired memory should not increment access_count."""
+        storage.store(key="tracked", value="data", ttl_days=7)
+        expire_memory("tracked")
+
+        # Attempt recall — should return None
+        assert storage.recall_by_key("tracked") is None
+
+        # Verify access_count was NOT incremented
+        with sqlite3.connect(temp_db) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT access_count FROM memories WHERE key = ?", ("tracked",)
+            ).fetchone()
+            assert row["access_count"] == 0
+
+    def test_lazy_cleanup_on_store(self, storage, expire_memory, temp_db):
+        """Storing a new memory should delete expired rows from the database."""
+        storage.store(key="old", value="expired data", ttl_days=7)
+        expire_memory("old")
+
+        # Storing a new memory triggers cleanup
+        storage.store(key="new", value="fresh data")
+
+        # Verify the expired row was physically deleted
+        with sqlite3.connect(temp_db) as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) as cnt FROM memories WHERE key = ?", ("old",)
+            ).fetchone()
+            assert row[0] == 0
+
+    def test_re_stored_memory_becomes_visible(self, storage, expire_memory):
+        """Re-storing an expired memory with new TTL should make it visible again."""
+        storage.store(key="revived", value="v1", ttl_days=7)
+        expire_memory("revived")
+
+        assert storage.recall_by_key("revived") is None
+
+        # Re-store with new TTL
+        storage.store(key="revived", value="v2", ttl_days=30)
+        recalled = storage.recall_by_key("revived")
+        assert recalled is not None
+        assert recalled.value == "v2"


### PR DESCRIPTION
## Summary

- Add `_TTL_FILTER` constant using `strftime('%Y-%m-%dT%H:%M:%f', 'now')` for correct lexicographic comparison with Python's isoformat timestamps
- Filter expired memories from all 8 read methods: `recall_by_key`, `search` (FTS), `search_semantic`, `list_memories`, `query`, `explore`, `aggregate`, and `search_weighted` (via delegation)
- Add lazy cleanup on `store()` that opportunistically deletes expired rows including `memories_vec` entries
- Prevent access_count increment for expired memories in `recall_by_key`

## Test plan

- [x] 11 new tests in `TestTTLEnforcement` class covering all read paths
- [x] `expire_memory` fixture in conftest.py for deterministic expiration testing
- [x] Tests verify: expired excluded from recall/search/list/query/explore/aggregate, non-expired still returned, no-TTL unaffected, access count not incremented, lazy cleanup on store, re-stored memory becomes visible
- [x] All 137 existing tests pass (8 skipped — semantic tests without embeddings)
- [x] `ruff format` and `ruff check` clean

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)